### PR TITLE
Don’t stop listening for events, to allow debug output all times

### DIFF
--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -103,7 +103,7 @@ def autoexit_command(debugger, command, result, internal_dict):
     printBacktraceTime = time.time() + detectDeadlockTimeout if detectDeadlockTimeout > 0 else None
     
     # This line prevents internal lldb listener from processing STDOUT/STDERR messages. Without it, an order of log writes is incorrect sometimes
-    debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
+    # debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
 
     event = lldb.SBEvent()
     


### PR DESCRIPTION
This PR allows debug output when running from a non-terminal environment. Otherwise, the output is not flushed continuously but only some chunks of it from time to time. Related to https://github.com/gluonhq/substrate/issues/165